### PR TITLE
Fix comments being displayed on error pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@ Custom Error Pages
 ==================
 This is the development version of this plugin.
 
-* Download the [latest stable version](http://downloads.wordpress.org/plugin/custom-error-pages.latest-stable.zip)
-* Official homepage - http://jesin.tk/wordpress-plugins/custom-error-pages/
-* WordPress plugin repository - http://wordpress.org/plugins/custom-error-pages/
+* Download the [latest stable version](https://downloads.wordpress.org/plugin/custom-error-pages.latest-stable.zip)
+* Official homepage - https://websistent.com/wordpress-plugins/custom-error-pages/
+* WordPress plugin repository - https://wordpress.org/plugins/custom-error-pages/

--- a/comments_disabler.php
+++ b/comments_disabler.php
@@ -1,0 +1,2 @@
+<?php
+// This is a empty template made to hide comments for generated error pages

--- a/plugin.php
+++ b/plugin.php
@@ -1,10 +1,10 @@
 <?php
 /*
 Plugin Name: Custom Error Pages
-Plugin URI: http://websistent.com/wordpress-plugins/custom-error-pages/
+Plugin URI: https://websistent.com/wordpress-plugins/custom-error-pages/
 Description: Create custom 401 and 403 error pages with any WordPress theme without writing a single line of code, set it up and forget it.
 Author: Jesin
-Author URI: http://websistent.com
+Author URI: https://websistent.com
 Version: 1.1
 */
 
@@ -33,6 +33,7 @@ if( !class_exists( 'Create_Custom_Error_Pages' ) && !class_exists( 'Custom_Error
 			add_action( 'init', array( $this, 'plugin_init' ) );
 			add_filter( 'query_vars', array( $this, 'add_status_query_var' ) ); //Add a custom query variable
 			add_action( 'parse_request', array( $this, 'get_status_query_var' ) ); //Check if the custom query variable exists
+			add_filter( 'comments_template', array( $this, 'plugin_disable_comments' ) );
 		}
 
 		function plugin_init()
@@ -62,6 +63,13 @@ if( !class_exists( 'Create_Custom_Error_Pages' ) && !class_exists( 'Custom_Error
 
 				//Create a custom error page based on our custom query variable
 				$create_custom_error_pages = new Create_Custom_Error_Pages( array( 'options' => $this->options, 'code' => $status ) );
+			}
+		}
+
+		function plugin_disable_comments( $comment_template ) {
+			global $post;
+			if( $post->ID == 0 ) {
+				return dirname( __FILE__ ) . '/comments_disabler.php';
 			}
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -16,8 +16,8 @@ WordPress offers inbuilt support for custom 404 pages on all themes. But what ab
 With this plugin you can easily create custom 401 and 403 error pages with any theme without writing a single line of code!!! And the best part is that you set it and forget it. Yes, you don't have to do any changes even if you change themes. The heading and text you want on 401 and 403 error pages are displayed on the currently active theme.
 
 = Further Reading =
-* [Create WordPress 401 and 403 error pages](http://websistent.com/wordpress-custom-403-401-error-page/) WITHOUT using this plugin
-* The [Custom Error Pages Plugin](http://websistent.com/wordpress-plugins/custom-error-pages/) official homepage.
+* [Create WordPress 401 and 403 error pages](https://websistent.com/wordpress-custom-403-401-error-page/) WITHOUT using this plugin
+* The [Custom Error Pages Plugin](https://websistent.com/wordpress-plugins/custom-error-pages/) official homepage.
 
 == Installation ==
 


### PR DESCRIPTION
This plugin when used with certain WordPress themes listed all comments on 401 and 403 error pages. This has been fixed by using a blank comments template file if a error page was being displayed.

In addition http URLs have been updated to https.